### PR TITLE
Add LavaSR-ONNX-Embedded to Community section

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ sf.write('output.wav', output_audio, 48000)
 - [GUI App](https://github.com/faxlab/LavaSR-Fast-Enhancer): GUI app for LavaSR.
 - [C++ implementation](https://github.com/Topping1/LavaSRcpp): Purely C++ implementation for LavaSR.
 - [Onnx implementation](https://github.com/Topping1/LavaSR-ONNX): Clean and simple Onnx implementation for LavaSR(
+- [ONNX Embedded](https://github.com/idocinthebox/LavaSR-ONNX-Embedded): ONNX runtime with weights embedded in graph, DirectML/NPU support, and export script.
 
 Thanks to the community for building on top of the model!
 


### PR DESCRIPTION
Hi! I built an alternate ONNX implementation for LavaSR and would love to be listed in the Community section.

**Repo:** https://github.com/idocinthebox/LavaSR-ONNX-Embedded

### Key differences from the existing ONNX implementation:

- **Weights embedded in ONNX graph** — no `.data` sidecar files needed (3 self-contained `.onnx` files)
- **DirectML provider support** — runs on NPU, GPU, and CPU via `onnxruntime-directml` (~2.5ms per chunk on DirectML vs ~100ms on CPU)
- **Static denoiser shapes** — `[1, 2, 63, 257]` fixed axes optimized for DirectML (avoids 45% slowdown from dynamic axes)
- **Export script included** — `export_onnx.py` for converting from PyTorch checkpoint to ONNX
- **98% model size reduction** — 54.5 MB total (embedded weights, FP32)

Thank you for the excellent work on LavaSR — it's been great to build on!